### PR TITLE
fix MycroftAI/lingua-franca/issues/59 + 225

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -811,7 +811,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
             # normalize step makes "in a day" -> "in day"
-            elif wordPrev and wordPrev == "in":
+            elif wordPrev and wordPrev  in ["in", "next", "within"]:
                 dayOffset += 1
                 start -= 1
                 used = 2
@@ -833,7 +833,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
             # normalize step makes "in a week" -> "in week"
-            elif wordPrev == "in":
+            elif wordPrev  in ["in", "next", "within"]:
                 dayOffset += 7
                 start -= 1
                 used = 2
@@ -869,7 +869,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                     start -= 1
                     used = 2
             # normalize step makes "in a weekend" -> "in weekend"
-            elif wordPrev == "in":
+            elif wordPrev  in ["in", "next", "within"]:
                 dayOffset += 7 - wkday  # next monday
                 start -= 1
                 used = 2
@@ -898,8 +898,8 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
             # normalize step makes "in a month" -> "in month"
-            elif wordPrev == "in":
-                dayOffset += 30
+            elif wordPrev  in ["in", "next", "within"]:
+                dayOffset += 31
                 start -= 1
                 used = 2
             elif wordPrev in past_markers:
@@ -925,7 +925,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
             # normalize step makes "in a year" -> "in year"
-            elif wordPrev == "in":
+            elif wordPrev in ["in", "next", "within"]:
                 dayOffset += 365
                 start -= 1
                 used = 2
@@ -1115,13 +1115,14 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 minOffset = 2
             elif wordNextNext == "seconds":
                 secOffset = 2
-        elif word == "hour" and wordPrev == "next":
+        # parse in a/next second/minute/hour
+        elif wordNext == "hour" and word in ["in", "next", "within"]:
             used += 2
             hrOffset = 1
-        elif word == "minute" and wordPrev == "next":
+        elif wordNext == "minute" and word in ["in", "next", "within"]:
             used += 2
             minOffset = 1
-        elif word == "second" and wordPrev == "next":
+        elif wordNext == "second" and word in ["in", "next", "within"]:
             used += 2
             secOffset = 1
         # parse half an hour, quarter hour
@@ -1148,17 +1149,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             used += 1
             hrAbs = -1
             minAbs = -1
-            # parse 5:00 am, 12:00 p.m., etc
-        # parse in a minute
-        elif word == "minute" and wordPrev == "in":
-            minOffset = 1
-            words[idx - 1] = ""
-            used += 1
-        # parse in a second
-        elif word == "second" and wordPrev == "in":
-            secOffset = 1
-            words[idx - 1] = ""
-            used += 1
+        # parse 5:00 am, 12:00 p.m., etc
         elif word[0].isdigit():
             isTime = True
             strHH = ""

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -695,6 +695,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     timeQualifiersPM = ['afternoon', 'evening', 'night', 'tonight']
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
     year_markers = ['in', 'on', 'of']
+    past_markers = ["last", "past"]
     markers = year_markers + ['at', 'by', 'this', 'around', 'for', "within"]
     days = ['monday', 'tuesday', 'wednesday',
             'thursday', 'friday', 'saturday', 'sunday']
@@ -813,7 +814,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 dayOffset = 7
                 start -= 1
                 used = 2
-            elif wordPrev == "last":
+            elif wordPrev in past_markers:
                 dayOffset = -7
                 start -= 1
                 used = 2
@@ -827,7 +828,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 monthOffset = 1
                 start -= 1
                 used = 2
-            elif wordPrev == "last":
+            elif wordPrev in past_markers:
                 monthOffset = -1
                 start -= 1
                 used = 2
@@ -841,7 +842,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 yearOffset = 1
                 start -= 1
                 used = 2
-            elif wordPrev == "last":
+            elif wordPrev in past_markers:
                 yearOffset = -1
                 start -= 1
                 used = 2
@@ -858,7 +859,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                     dayOffset += 7
                 used += 1
                 start -= 1
-            elif wordPrev == "last":
+            elif wordPrev in past_markers:
                 dayOffset -= 7
                 used += 1
                 start -= 1
@@ -924,6 +925,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
         validFollowups.append("yesterday")
         validFollowups.append("next")
         validFollowups.append("last")
+        validFollowups.append("past")
         validFollowups.append("now")
         validFollowups.append("this")
         if (word == "from" or word == "after") and wordNext in validFollowups:

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -842,8 +842,13 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
         elif word == "week" and not fromFlag and wordNext == "ago":
-            dayOffset -= 7
-            used = 2
+            if wordPrev[0].isdigit():
+                dayOffset -= int(wordPrev) * 7
+                start -= 1
+                used = 3
+            else:
+                dayOffset -= 7
+                used = 2
         elif word == "weekend" and not fromFlag and wordPrev and wordNext != "ago":
             # in/after X weekends
             if wordPrev[0].isdigit():

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -1115,6 +1115,15 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 minOffset = 2
             elif wordNextNext == "seconds":
                 secOffset = 2
+        elif word == "hour" and wordPrev == "next":
+            used += 2
+            hrOffset = 1
+        elif word == "minute" and wordPrev == "next":
+            used += 2
+            minOffset = 1
+        elif word == "second" and wordPrev == "next":
+            used += 2
+            secOffset = 1
         # parse half an hour, quarter hour
         elif word == "hour" and \
                 (wordPrev in markers or wordPrevPrev in markers):

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -953,13 +953,6 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('i had things to do 2 years ago', dt)[0],
             datetime(2015, 6, 2, tzinfo=default_timezone()))
 
-    @unittest.skip("not yet implemented")
-    def test_extract_this_en(self):
-        dt = datetime(2017, 6, 1)
-        self.assertEqual(
-            extract_datetime('i have things to do this week', dt)[0],
-            datetime(2017, 6, 1, tzinfo=default_timezone()))
-
     def test_extract_with_other_tzinfo(self):
         local_tz = default_timezone()
         local_dt = datetime(2019, 7, 4, 7, 1, 2, tzinfo=local_tz)

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -883,17 +883,62 @@ class TestNormalize(unittest.TestCase):
             datetime(2018, 6, 1, tzinfo=default_timezone()))
 
         self.assertEqual(
+            extract_datetime('i have things to do in a second', dt)[0],
+            datetime(2017, 6, 1, 0, 0, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a second', dt)[0],
+            extract_datetime('i have things to do within a second', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a minute', dt)[0],
+            datetime(2017, 6, 1, 0, 1, 0, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a minute', dt)[0],
+            extract_datetime('i have things to do within a minute', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a minute', dt)[0],
+            extract_datetime('i have things to do in 60 seconds', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in an hour', dt)[0],
+            datetime(2017, 6, 1, 1, 0, 0, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in an hour', dt)[0],
+            extract_datetime('i have things to do within the hour', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a day', dt)[0],
+            extract_datetime('i have things to do in 24 hours', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do within a day', dt)[0],
+            extract_datetime('i have things to do in 24 hours', dt)[0])
+        self.assertEqual(
             extract_datetime('i have things to do in a day', dt)[0],
             datetime(2017, 6, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('i have things to do in a week', dt)[0],
             datetime(2017, 6, 8, tzinfo=default_timezone()))
         self.assertEqual(
+            extract_datetime('i have things to do in a week', dt)[0],
+            extract_datetime('i have things to do within a week', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a week', dt)[0],
+            extract_datetime('i have things to do in 7 days', dt)[0])
+        self.assertEqual(
             extract_datetime('i have things to do in a month', dt)[0],
-            datetime(2017, 7, 1, tzinfo=default_timezone()))
+            extract_datetime('i have things to do in 31 days', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a month', dt)[0],
+            extract_datetime('i have things to do within the month', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a month', dt)[0],
+            datetime(2017, 7, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('i have things to do in a year', dt)[0],
             datetime(2018, 6, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a year', dt)[0],
+            extract_datetime('i have things to do in 365 days', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in a year', dt)[0],
+            extract_datetime('i have things to do within the year', dt)[0])
 
         self.assertEqual(
             extract_datetime('i have things to do in 1 day', dt)[0],

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -926,14 +926,32 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('i had things to do a day ago', dt)[0],
             datetime(2017, 5, 31, tzinfo=default_timezone()))
         self.assertEqual(
+            extract_datetime('i had things to do 2 days ago', dt)[0],
+            datetime(2017, 5, 30, tzinfo=default_timezone()))
+        self.assertEqual(
             extract_datetime('i had things to do a week ago', dt)[0],
             datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do 2 weeks ago', dt)[0],
+            datetime(2017, 5, 18, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('i had things to do a month ago', dt)[0],
             datetime(2017, 5, 1, tzinfo=default_timezone()))
         self.assertEqual(
+            extract_datetime('i had things to do 2 months ago', dt)[0],
+            extract_datetime('i had things to do 62 days ago', dt)[0])
+        self.assertEqual(
+            extract_datetime('i had things to do 2 months ago', dt)[0],
+            datetime(2017, 3, 31, tzinfo=default_timezone()))
+        self.assertEqual(
             extract_datetime('i had things to do a year ago', dt)[0],
             datetime(2016, 6, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do 2 years ago', dt)[0],
+            extract_datetime('i had things to do 730 days ago', dt)[0])
+        self.assertEqual(
+            extract_datetime('i had things to do 2 years ago', dt)[0],
+            datetime(2015, 6, 2, tzinfo=default_timezone()))
 
     @unittest.skip("not yet implemented")
     def test_extract_this_en(self):

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -858,8 +858,17 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('i had things to do 2 weekends ago', dt)[0],
             datetime(2017, 5, 19, tzinfo=default_timezone()))
 
-    def test_extract_next_last_in_en(self):
-        dt = datetime(2017, 6, 1)
+    def test_extract_next_in_en(self):
+        dt = datetime(2017, 6, 1, 0, 0, 0)
+        self.assertEqual(
+            extract_datetime('i have things to do next second', dt)[0],
+            datetime(2017, 6, 1, 0, 0, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do next minute', dt)[0],
+            datetime(2017, 6, 1, 0, 1, 0, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do next hour', dt)[0],
+            datetime(2017, 6, 1, 1, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('i have things to do next day', dt)[0],
             datetime(2017, 6, 2, tzinfo=default_timezone()))
@@ -872,24 +881,6 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(
             extract_datetime('i have things to do next year', dt)[0],
             datetime(2018, 6, 1, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do last week', dt)[0],
-            datetime(2017, 5, 25, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do the past week', dt)[0],
-            datetime(2017, 5, 25, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do last month', dt)[0],
-            datetime(2017, 5, 1, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do the past month', dt)[0],
-            datetime(2017, 5, 1, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do last year', dt)[0],
-            datetime(2016, 6, 1, tzinfo=default_timezone()))
-        self.assertEqual(
-            extract_datetime('i had things to do the past year', dt)[0],
-            datetime(2016, 6, 1, tzinfo=default_timezone()))
 
         self.assertEqual(
             extract_datetime('i have things to do in a day', dt)[0],
@@ -919,6 +910,27 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(
             extract_datetime('i have things to do in 1 year', dt)[0],
             datetime(2018, 6, 1, tzinfo=default_timezone()))
+
+    def test_extract_last_past_en(self):
+        dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i had things to do last week', dt)[0],
+            datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past week', dt)[0],
+            datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do last month', dt)[0],
+            datetime(2017, 5, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past month', dt)[0],
+            datetime(2017, 5, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do last year', dt)[0],
+            datetime(2016, 6, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past year', dt)[0],
+            datetime(2016, 6, 1, tzinfo=default_timezone()))
 
     def test_extract_ago_en(self):
         dt = datetime(2017, 6, 1)

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -817,8 +817,52 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('On 24th of may I want a reminder', may_date)[0],
             datetime(2019, 5, 24, 0, 0, 0, tzinfo=default_timezone()))
 
-    def test_extract_next_last_en(self):
+    def test_extract_weekend_en(self):
         dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i have things to do next weekend', dt)[0],
+            datetime(2017, 6, 4, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a weekend', dt)[0],
+            datetime(2017, 6, 5, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a weekend', dt)[0],
+            extract_datetime('i have things to do next monday', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 weekend', dt)[0],
+            extract_datetime('i have things to do next monday', dt)[0])
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 weekend', dt)[0],
+            datetime(2017, 6, 5, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in 2 weekends', dt)[0],
+            datetime(2017, 6, 12, tzinfo=default_timezone()))
+
+        self.assertEqual(
+            extract_datetime('i had things to do last weekend', dt)[0],
+            extract_datetime('i had things to do last saturday', dt)[0])
+        self.assertEqual(
+            extract_datetime('i had things to do last weekend', dt)[0],
+            datetime(2017, 5, 27, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do past weekend', dt)[0],
+            datetime(2017, 5, 27, tzinfo=default_timezone()))
+
+        self.assertEqual(
+            extract_datetime('i had things to do a weekend ago', dt)[0],
+            extract_datetime('i had things to do last friday', dt)[0])
+        self.assertEqual(
+            extract_datetime('i had things to do a weekend ago', dt)[0],
+            datetime(2017, 5, 26, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do 2 weekends ago', dt)[0],
+            datetime(2017, 5, 19, tzinfo=default_timezone()))
+
+    def test_extract_next_last_in_en(self):
+        dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i have things to do next day', dt)[0],
+            datetime(2017, 6, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('i have things to do next week', dt)[0],
             datetime(2017, 6, 8, tzinfo=default_timezone()))
@@ -847,6 +891,51 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('i had things to do the past year', dt)[0],
             datetime(2016, 6, 1, tzinfo=default_timezone()))
 
+        self.assertEqual(
+            extract_datetime('i have things to do in a day', dt)[0],
+            datetime(2017, 6, 2, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a week', dt)[0],
+            datetime(2017, 6, 8, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a month', dt)[0],
+            datetime(2017, 7, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in a year', dt)[0],
+            datetime(2018, 6, 1, tzinfo=default_timezone()))
+
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 day', dt)[0],
+            datetime(2017, 6, 2, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in 2 days', dt)[0],
+            datetime(2017, 6, 3, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 week', dt)[0],
+            datetime(2017, 6, 8, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 month', dt)[0],
+            datetime(2017, 7, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do in 1 year', dt)[0],
+            datetime(2018, 6, 1, tzinfo=default_timezone()))
+
+    def test_extract_ago_en(self):
+        dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i had things to do a day ago', dt)[0],
+            datetime(2017, 5, 31, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do a week ago', dt)[0],
+            datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do a month ago', dt)[0],
+            datetime(2017, 5, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do a year ago', dt)[0],
+            datetime(2016, 6, 1, tzinfo=default_timezone()))
+
+    @unittest.skip("not yet implemented")
     def test_extract_this_en(self):
         dt = datetime(2017, 6, 1)
         self.assertEqual(

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -800,6 +800,30 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('feed fish at 10 o\'clock', evening)[0],
             datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
+    def test_extract_later_en(self):
+        dt = datetime(2017, 1, 1, 13, 12, 30)
+        self.assertEqual(
+            extract_datetime('10 seconds later', dt)[0],
+            datetime(2017, 1, 1, 13, 12, 40, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('15 minutes later', dt)[0],
+            datetime(2017, 1, 1, 13, 27, 30, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('12 hours later', dt)[0],
+            datetime(2017, 1, 2, 1, 12, 30, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('28 days later', dt)[0],
+            datetime(2017, 1, 29, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('2 weeks later', dt)[0],
+            datetime(2017, 1, 15, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('6 months later', dt)[0],
+            datetime(2017, 7, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('10 years later', dt)[0],
+            datetime(2027, 1, 1, tzinfo=default_timezone()))
+
     def test_extract_date_with_may_I_en(self):
         now = datetime(2019, 7, 4, 8, 1, 2, tzinfo=default_timezone())
         may_date = datetime(2019, 5, 2, 10, 11, 20, tzinfo=default_timezone())
@@ -980,9 +1004,6 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(
             extract_datetime('i have things to do in a week', dt)[0],
             extract_datetime('i have things to do within a week', dt)[0])
-        self.assertEqual(
-            extract_datetime('i have things to do in a week', dt)[0],
-            extract_datetime('i have things to do in 7 days', dt)[0])
         self.assertEqual(
             extract_datetime('i have things to do in a month', dt)[0],
             extract_datetime('i have things to do within the month', dt)[0])

--- a/test/unittests/test_parse_en.py
+++ b/test/unittests/test_parse_en.py
@@ -817,6 +817,42 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('On 24th of may I want a reminder', may_date)[0],
             datetime(2019, 5, 24, 0, 0, 0, tzinfo=default_timezone()))
 
+    def test_extract_next_last_en(self):
+        dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i have things to do next week', dt)[0],
+            datetime(2017, 6, 8, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do next month', dt)[0],
+            datetime(2017, 7, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i have things to do next year', dt)[0],
+            datetime(2018, 6, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do last week', dt)[0],
+            datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past week', dt)[0],
+            datetime(2017, 5, 25, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do last month', dt)[0],
+            datetime(2017, 5, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past month', dt)[0],
+            datetime(2017, 5, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do last year', dt)[0],
+            datetime(2016, 6, 1, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime('i had things to do the past year', dt)[0],
+            datetime(2016, 6, 1, tzinfo=default_timezone()))
+
+    def test_extract_this_en(self):
+        dt = datetime(2017, 6, 1)
+        self.assertEqual(
+            extract_datetime('i have things to do this week', dt)[0],
+            datetime(2017, 6, 1, tzinfo=default_timezone()))
+
     def test_extract_with_other_tzinfo(self):
         local_tz = default_timezone()
         local_dt = datetime(2019, 7, 4, 7, 1, 2, tzinfo=local_tz)


### PR DESCRIPTION
closes #14 , partially fixes #15 

- handle weekends 
- handle **last**/past second/minute/hour/day/week/weekend/month/year/decade
- handle **next** second/minute/hour/day/week/weekend/month/year
- handle **in a** second/minute/hour/day/week/weekend/month/year
- handle **#N** second/minute/hour/day/week/weekend/month/year/decades/centuries/millenium **ago** / **earlier**
- handle **within** a second/minute/day/hour/week/weekend/month/year
- handle **{float}**/fractional decades/centuries/millenium e.g. `"in 1.5 centuries"`

notes on disambiguation:
- in a month -> + 1 month timedelta
- next month -> day 1 of next month
- we can not disambiguate within a/the {unit} because normalize step removes the articles
   - "within a month" -> month is a timedelta of 30 days
   - "within the month" -> before 1st day of next month
   
TODO:
- parse "this week/day/month/xxx" in follow up PR
