### PR TITLE
fix inconsitency in nice_time_de

### DIFF
--- a/lingua_franca/lang/format_de.py
+++ b/lingua_franca/lang/format_de.py
@@ -210,7 +210,7 @@ def pronounce_ordinal_de(number):
 def nice_time_de(dt, speech=True, use_24hour=False, use_ampm=False):
     """
     Format a time to a comfortable human format
-    For example, generate 'five thirty' for speech or '5:30' for
+    For example, generate 'ein uhr eins' for speech or '01:01 Uhr' for
     text display.
     Args:
         dt (datetime): date to format (assumes already in local timezone)
@@ -220,71 +220,56 @@ def nice_time_de(dt, speech=True, use_24hour=False, use_ampm=False):
     Returns:
         (str): The formatted time string
     """
+    string = ""
     if not speech:
         if use_24hour:
-            # e.g. "03:01" or "14:22"
-            string = dt.strftime("%H:%M")
+            string = f"{dt.strftime('%H:%M')} uhr"
         else:
-            if use_ampm:
-                # e.g. "3:01 AM" or "2:22 PM"
-                string = dt.strftime("%I:%M %p")
-            else:
-                # e.g. "3:01" or "2:22"
-                string = dt.strftime("%I:%M")
-            if string[0] == '0':
-                string = string[1:]  # strip leading zeros
-        return string
+            string = f"{dt.strftime('%I:%M')} uhr"
 
-    # Generate a speakable version of the time
-    speak = ""
-    if use_24hour:
+    # Generate a speakable version of the time"
+    elif use_24hour:
         if dt.hour == 1:
-            speak += "ein"  # 01:00 is "ein Uhr" not "eins Uhr"
+            string += "ein"  # 01:00 is "ein Uhr" not "eins Uhr"
         else:
-            speak += pronounce_number_de(dt.hour)
-        speak += " Uhr"
-        if not dt.minute == 0:  # zero minutes are not pronounced, 13:00 is
-            # "13 Uhr" not "13 hundred hours"
-            speak += " " + pronounce_number_de(dt.minute)
-
-        return speak  # ampm is ignored when use_24hour is true
+            string += pronounce_number_de(dt.hour)
+        string += " uhr"
+        if not dt.minute == 0:  # zero minutes are not pronounced
+            string += " " + pronounce_number_de(dt.minute)
     else:
+        next_hour = (dt.hour + 1) % 12 or 12
         if dt.hour == 0 and dt.minute == 0:
-            return "Mitternacht"
+            return "mitternacht"
         elif dt.hour == 12 and dt.minute == 0:
-            return "Mittag"
+            return "mittag"
         elif dt.minute == 15:
-            # sentence relative to next hour and 0 spoken as 12
-            next_hour = (dt.hour + 1) % 12 or 12
-            speak = "viertel " + pronounce_number_de(next_hour)
+            string = "viertel " + pronounce_number_de(next_hour)
         elif dt.minute == 30:
-            next_hour = (dt.hour + 1) % 12 or 12
-            speak = "halb " + pronounce_number_de(next_hour)
+            string = "halb " + pronounce_number_de(next_hour)
         elif dt.minute == 45:
-            next_hour = (dt.hour + 1) % 12 or 12
-            speak = "dreiviertel " + pronounce_number_de(next_hour)
+            string = "dreiviertel " + pronounce_number_de(next_hour)
         else:
-            hour = dt.hour % 12 or 12  # 12 hour clock and 0 is spoken as 12
+            hour = dt.hour % 12
             if hour == 1:  # 01:00 and 13:00 is "ein Uhr" not "eins Uhr"
-                speak += 'ein'
+                string += 'ein'
             else:
-                speak += pronounce_number_de(hour)
-            speak += " Uhr"
+                string += pronounce_number_de(hour)
+            string += " uhr"
 
             if not dt.minute == 0:
-                speak += " " + pronounce_number_de(dt.minute)
+                string += " " + pronounce_number_de(dt.minute)
 
-        if use_ampm:
-            if 3 <= dt.hour < 12:
-                speak += " morgens"  # 03:00 - 11:59 morgens/in the morning
-            elif 12 <= dt.hour < 18:
-                speak += " nachmittags"  # 12:01 - 17:59 nachmittags/afternoon
-            elif 18 <= dt.hour < 22:
-                speak += " abends"  # 18:00 - 21:59 abends/evening
-            else:
-                speak += " nachts"  # 22:00 - 02:59 nachts/at night
+    if use_ampm:
+        if 3 <= dt.hour < 12:
+            string += " morgens"  # 03:00 - 11:59 morgens/in the morning
+        elif 12 <= dt.hour < 18:
+            string += " nachmittags"  # 12:01 - 17:59 nachmittags/afternoon
+        elif 18 <= dt.hour < 22:
+            string += " abends"  # 18:00 - 21:59 abends/evening
+        else:
+            string += " nachts"  # 22:00 - 02:59 nachts/at night
 
-        return speak
+    return string
 
 
 def nice_response_de(text):

--- a/lingua_franca/res/text/de-de/date_time_test.json
+++ b/lingua_franca/res/text/de-de/date_time_test.json
@@ -37,7 +37,7 @@
     "9": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2019, 2, 6, 0, 2, 3", "assertEqual": "Sonntag, vierter Februar, zwei tausend achtzehn"}
   },
   "test_nice_date_time": {
-    "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "False", "use_ampm": "True", "assertEqual": "Dienstag, einunddreißigster Januar, zwei tausend siebzehn um ein Uhr zweiundzwanzig nachmittags"},
-    "2": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "True", "use_ampm": "False", "assertEqual": "Dienstag, einunddreißigster Januar, zwei tausend siebzehn um dreizehn Uhr zweiundzwanzig"}
+    "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "False", "use_ampm": "True", "assertEqual": "Dienstag, einunddreißigster Januar, zwei tausend siebzehn um ein uhr zweiundzwanzig nachmittags"},
+    "2": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "True", "use_ampm": "False", "assertEqual": "Dienstag, einunddreißigster Januar, zwei tausend siebzehn um dreizehn uhr zweiundzwanzig"}
   }
 }

--- a/test/unittests/test_format_de.py
+++ b/test/unittests/test_format_de.py
@@ -223,98 +223,98 @@ class TestNiceDateFormat_de(unittest.TestCase):
                                13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt),
-                         "ein Uhr zweiundzwanzig")
+                         "ein uhr zweiundzwanzig")
         self.assertEqual(nice_time(dt, use_ampm=True),
-                         "ein Uhr zweiundzwanzig nachmittags")
+                         "ein uhr zweiundzwanzig nachmittags")
         self.assertEqual(nice_time(dt, speech=False),
-                         "1:22")
+                         "01:22 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "1:22 PM")
+                         "01:22 uhr nachmittags")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "13:22")
+                         "13:22 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "13:22")
+                         "13:22 uhr nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "dreizehn Uhr zweiundzwanzig")
+                         "dreizehn uhr zweiundzwanzig nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "dreizehn Uhr zweiundzwanzig")
+                         "dreizehn uhr zweiundzwanzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "ein Uhr")
+                         "ein uhr")
         self.assertEqual(nice_time(dt, use_ampm=True),
-                         "ein Uhr nachmittags")
+                         "ein uhr nachmittags")
         self.assertEqual(nice_time(dt, speech=False),
-                         "1:00")
+                         "01:00 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "1:00 PM")
+                         "01:00 uhr nachmittags")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "13:00")
+                         "13:00 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "13:00")
+                         "13:00 uhr nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "dreizehn Uhr")
+                         "dreizehn uhr nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "dreizehn Uhr")
+                         "dreizehn uhr")
 
         dt = datetime.datetime(2017, 1, 31,
                                13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "ein Uhr zwei")
+                         "ein uhr zwei")
         self.assertEqual(nice_time(dt, use_ampm=True),
-                         "ein Uhr zwei nachmittags")
+                         "ein uhr zwei nachmittags")
         self.assertEqual(nice_time(dt, speech=False),
-                         "1:02")
+                         "01:02 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "1:02 PM")
+                         "01:02 uhr nachmittags")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "13:02")
+                         "13:02 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "13:02")
+                         "13:02 uhr nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "dreizehn Uhr zwei")
+                         "dreizehn uhr zwei nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "dreizehn Uhr zwei")
+                         "dreizehn uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
                                0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "zwölf Uhr zwei")
+                         "null uhr zwei")
         self.assertEqual(nice_time(dt, use_ampm=True),
-                         "zwölf Uhr zwei nachts")
+                         "null uhr zwei nachts")
         self.assertEqual(nice_time(dt, speech=False),
-                         "12:02")
+                         "12:02 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "12:02 AM")
+                         "12:02 uhr nachts")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "00:02")
+                         "00:02 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "00:02")
+                         "00:02 uhr nachts")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "null Uhr zwei")
+                         "null uhr zwei nachts")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "null Uhr zwei")
+                         "null uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
                                12, 15, 9, tzinfo=default_timezone())
@@ -323,56 +323,56 @@ class TestNiceDateFormat_de(unittest.TestCase):
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "viertel eins nachmittags")
         self.assertEqual(nice_time(dt, speech=False),
-                         "12:15")
+                         "12:15 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "12:15 PM")
+                         "12:15 uhr nachmittags")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "12:15")
+                         "12:15 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "12:15")
+                         "12:15 uhr nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "zwölf Uhr fünfzehn")
+                         "zwölf uhr fünfzehn nachmittags")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "zwölf Uhr fünfzehn")
+                         "zwölf uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
                                19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "sieben Uhr vierzig")
+                         "sieben uhr vierzig")
         self.assertEqual(nice_time(dt, use_ampm=True),
-                         "sieben Uhr vierzig abends")
+                         "sieben uhr vierzig abends")
         self.assertEqual(nice_time(dt, speech=False),
-                         "7:40")
+                         "07:40 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
-                         "7:40 PM")
+                         "07:40 uhr abends")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
-                         "19:40")
+                         "19:40 uhr")
         self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
-                         "19:40")
+                         "19:40 uhr abends")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
-                         "neunzehn Uhr vierzig")
+                         "neunzehn uhr vierzig abends")
         self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
-                         "neunzehn Uhr vierzig")
+                         "neunzehn uhr vierzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=True),
-                         "ein Uhr fünfzehn")
+                         "ein uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "ein Uhr fünfunddreißig")
+                         "ein uhr fünfunddreißig")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 45, 00, tzinfo=default_timezone())
@@ -382,12 +382,12 @@ class TestNiceDateFormat_de(unittest.TestCase):
         dt = datetime.datetime(2017, 1, 31,
                                4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "vier Uhr fünfzig")
+                         "vier uhr fünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
-                         "fünf Uhr fünfundfünfzig")
+                         "fünf uhr fünfundfünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                5, 30, 00, tzinfo=default_timezone())


### PR DESCRIPTION
The resulting string was all over the place. 
Speakable and displayable date strings produced with `use_ampm=True` used both "am/pm" and the german implementation (morgens/nachmittags/abends/nachts, ie. the time of day), depending on `use_24hour`

This now produces a string that is in line with quality STT transcriptions (ie reusable in such context)
spoken text "2 uhr 30" -> STT "2:30 uhr"

unittests were updated