### PR TITLE
fix nice date utils

### DIFF
--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -28,7 +28,7 @@ from lingua_franca.internal import localized_function, \
     get_full_lang_code, get_default_lang, get_default_loc, \
     is_supported_full_lang, _raise_unsupported_language, \
     UnsupportedLanguageError, NoneLangWarning, InvalidLangWarning, \
-    FunctionNotLocalizedError, resolve_resource_file, FunctionNotLocalizedError
+    FunctionNotLocalizedError, resolve_resource_file
 from lingua_franca.time import now_local
 
 

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -28,8 +28,7 @@ from lingua_franca.internal import localized_function, \
     get_full_lang_code, get_default_lang, get_default_loc, \
     is_supported_full_lang, _raise_unsupported_language, \
     UnsupportedLanguageError, NoneLangWarning, InvalidLangWarning, \
-    FunctionNotLocalizedError, resolve_resource_file, FunctionNotLocalizedError,\
-    get_primary_lang_code
+    FunctionNotLocalizedError, resolve_resource_file, FunctionNotLocalizedError
 from lingua_franca.time import now_local
 
 
@@ -402,7 +401,10 @@ def nice_day(dt, date_format='MDY', include_month=True, lang=""):
 
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
 def nice_weekday(dt, lang=""):
-    if lang in date_time_format.lang_config.keys():
+    full_code = get_full_lang_code(lang)
+    date_time_format.cache(full_code)
+
+    if full_code in date_time_format.lang_config.keys():
         localized_day_names = list(
             date_time_format.lang_config[lang]['weekday'].values())
         weekday = localized_day_names[dt.weekday()]
@@ -413,7 +415,10 @@ def nice_weekday(dt, lang=""):
 
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
 def nice_month(dt, date_format='MDY', lang=""):
-    if lang in date_time_format.lang_config.keys():
+    full_code = get_full_lang_code(lang)
+    date_time_format.cache(full_code)
+
+    if full_code in date_time_format.lang_config.keys():
         localized_month_names = date_time_format.lang_config[lang]['month']
         month = localized_month_names[str(int(dt.strftime("%m")))]
     else:
@@ -446,7 +451,7 @@ def nice_year(dt, lang='', bc=False):
 
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
 def get_date_strings(dt=None, date_format='MDY', time_format="full", lang=""):
-    lang = get_primary_lang_code(lang)
+    lang = get_full_lang_code(lang)
     dt = dt or now_local()
     timestr = nice_time(dt, lang, speech=False,
                          use_24hour=time_format == "full")

--- a/test/unittests/test_format.py
+++ b/test/unittests/test_format.py
@@ -24,12 +24,18 @@ from dateutil import tz
 # TODO either write a getter for lingua_franca.internal._SUPPORTED_LANGUAGES,
 # or make it public somehow
 from lingua_franca import load_language, unload_language, set_default_lang
-from lingua_franca.format import date_time_format
-from lingua_franca.format import nice_date
-from lingua_franca.format import nice_date_time
-from lingua_franca.format import nice_number
-from lingua_franca.format import nice_time
-from lingua_franca.format import nice_year
+from lingua_franca.format import (
+    date_time_format,
+    nice_date,
+    nice_date_time,
+    nice_number,
+    nice_time,
+    nice_year,
+    nice_day,
+    nice_month,
+    nice_weekday,
+    get_date_strings
+)
 from lingua_franca.lang.format_common import convert_to_mixed_fraction as cmf
 from lingua_franca.time import default_timezone, set_default_tz, now_local, \
     to_local
@@ -213,6 +219,69 @@ class TestNiceDateFormat(unittest.TestCase):
             unload_language(lang)
 
         set_default_lang('en')
+
+
+class TestNiceDateUtils(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lang = 'en-us'
+
+    def test_nice_day(self):
+        # Test with include_month=True
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_day(dt, 'MDY', True, self.lang), "October 31")
+        self.assertEqual(nice_day(dt, 'DMY', True, self.lang), "31 October")
+
+        # Test with include_month=False
+        self.assertEqual(nice_day(dt, include_month=False, lang=self.lang), "31")
+
+    def test_nice_month(self):
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_month(dt, lang=self.lang), "October")
+
+    def test_nice_weekday(self):
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_weekday(dt, lang=self.lang), "Monday")
+    
+    def test_get_date_strings(self):
+        # Test with default arguments
+        dt = datetime.datetime(2022, 10, 31, 13, 30, 0)
+        expected_output = {
+            "date_string": "10/31/2022",
+            "time_string": "1:30",
+            "month_string": "October",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Monday"
+        }
+        self.assertEqual(get_date_strings(dt,
+                                          time_format="half",
+                                          lang=self.lang), expected_output)
+
+        # Test with different date_format
+        expected_output = {
+            "date_string": "31/10/2022",
+            "time_string": "1:30",
+            "month_string": "October",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Monday"
+        }
+        self.assertEqual(get_date_strings(dt,
+                                          time_format="half",
+                                          date_format='DMY',
+                                          lang=self.lang), expected_output)
+
+        # Test with different time_format
+        expected_output = {
+            "date_string": "10/31/2022",
+            "time_string": "13:30",
+            "month_string": "October",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Monday"
+        }
+        self.assertEqual(get_date_strings(dt, lang=self.lang), expected_output)        
 
 
 class TestMixedFraction(unittest.TestCase):

--- a/test/unittests/test_format_de.py
+++ b/test/unittests/test_format_de.py
@@ -18,12 +18,18 @@ import datetime
 
 from lingua_franca import get_default_lang, set_default_lang, load_language, \
     unload_language
-from lingua_franca.format import nice_number
-from lingua_franca.format import nice_time
-from lingua_franca.format import pronounce_number
+from lingua_franca.format import (
+    nice_number,
+    nice_time,
+    pronounce_number,
+    join_list,
+    nice_day,
+    nice_month,
+    nice_weekday,
+    get_date_strings
+)
 from lingua_franca.lang.format_de import nice_response_de
 from lingua_franca.lang.format_de import pronounce_ordinal_de
-from lingua_franca.format import join_list
 from lingua_franca.time import default_timezone
 
 
@@ -210,7 +216,7 @@ class TestPronounceNumber(unittest.TestCase):
 
 # def nice_time(dt, lang="de-de", speech=True, use_24hour=False,
 #              use_ampm=False):
-class TestNiceDateFormat_de(unittest.TestCase):
+class TestNiceTime_de(unittest.TestCase):
     def setUp(self):
         self.old_lang = get_default_lang()
         set_default_lang("de-de")
@@ -393,6 +399,72 @@ class TestNiceDateFormat_de(unittest.TestCase):
                                5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "halb sechs morgens")
+
+
+class TestNiceDateUtils(unittest.TestCase):
+    def setUp(self):
+        self.old_lang = get_default_lang()
+        self.lang = "de-de"
+        set_default_lang(self.lang)
+
+    def tearDown(self):
+        set_default_lang(self.old_lang)
+
+    def test_nice_day(self):
+        # Test with include_month=True
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_day(dt, 'MDY', True, self.lang), "Oktober 31")
+        self.assertEqual(nice_day(dt, 'DMY', True, self.lang), "31 Oktober")
+
+        # Test with include_month=False
+        self.assertEqual(nice_day(dt, include_month=False, lang=self.lang), "31")
+
+    def test_nice_month(self):
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_month(dt, lang=self.lang), "Oktober")
+
+    def test_nice_weekday(self):
+        dt = datetime.datetime(2022, 10, 31)
+        self.assertEqual(nice_weekday(dt, lang=self.lang), "Montag")
+    
+    def test_get_date_strings(self):
+        # Test with default arguments
+        dt = datetime.datetime(2022, 10, 31, 13, 30, 0)
+        expected_output = {
+            "date_string": "10/31/2022",
+            "time_string": "13:30 uhr",
+            "month_string": "Oktober",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Montag"
+        }
+        self.assertEqual(get_date_strings(dt, lang=self.lang), expected_output)
+
+        # Test with different date_format
+        expected_output = {
+            "date_string": "31/10/2022",
+            "time_string": "13:30 uhr",
+            "month_string": "Oktober",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Montag"
+        }
+        self.assertEqual(get_date_strings(dt,
+                                          date_format='DMY',
+                                          lang=self.lang), expected_output)
+
+        # Test with different time_format
+        expected_output = {
+            "date_string": "10/31/2022",
+            "time_string": "01:30 uhr",
+            "month_string": "Oktober",
+            "day_string": "31",
+            "year_string": "2022",
+            "weekday_string": "Montag"
+        }
+        self.assertEqual(get_date_strings(dt,
+                                          time_format="half",
+                                          lang=self.lang), expected_output)        
 
 
 class TestJoinList_de(unittest.TestCase):


### PR DESCRIPTION
## Problem:

- DateTimeFormat needs the full language code initialized
- since languages are not cached beforehand, it returns english `date_strings`

This also fixes Homescreen displaying english strings (ofc)