### PR TITLE
Update common_data_nl.py

### DIFF
--- a/lingua_franca/lang/common_data_nl.py
+++ b/lingua_franca/lang/common_data_nl.py
@@ -21,7 +21,7 @@ _ARTICLES_NL = {'de', 'het'}
 
 _NUM_STRING_NL = {
     0: 'nul',
-    1: 'een',
+    1: 'één',
     2: 'twee',
     3: 'drie',
     4: 'vier',


### PR DESCRIPTION
één versus een (last one is also 'a', like in "a person" etc. één means one, like in "one person")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the representation of the numeral `1` in Dutch to include the correct accent, changing it from 'een' to 'één'. 

This enhancement ensures accurate language representation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->